### PR TITLE
Fixes wordnet (NLTK) import error

### DIFF
--- a/wordmaster.py
+++ b/wordmaster.py
@@ -2,7 +2,8 @@ from textblob import TextBlob
 from datetime import datetime
 from nltk.corpus import wordnet
 import ety
-
+import nltk
+nltk.download('wordnet')
 from langcodes import langcodes
 
 print(


### PR DESCRIPTION
### Fixes this error:

```Resource wordnet not found.
  Please use the NLTK Downloader to obtain the resource:

  >>> import nltk
  >>> nltk.download('wordnet')
  
  Attempted to load corpora/wordnet

```